### PR TITLE
v2 Upgrade

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check Helm Chart Document
         run: |
           code=0
-          docker run --rm -v "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:v1.5.0 -t ./README.md.gotmpl -o ../../README.md || code=$?;
+          yarn helm-docs || code=$?;
           if [ "$code" != "0" ]; then 
             echo "Failed to run helm-docs!";
             exit 1;
@@ -40,7 +40,7 @@ jobs:
           git ls-files -m | grep -i readme.md || code=$?;
           if [ "$code" == "0" ]; then
             echo -e "Some of helm chart docs are required to be updated using the [helm-docs](https://github.com/norwoodj/helm-docs) tool. \n
-            Please run helm-docs (v1.5.0) at project root, review & commit docs changes and push a new commit.";
+            Please run helm-docs (v1.11.0) at project root, review & commit docs changes and push a new commit.";
             exit 1;
           else 
             echo -e "helm docs check passed. helm docs update is not required.";

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,6 @@ on: push
 
 env:
   REPO_NAME: magda-auth-oidc
-  # Github account username (used for access github registry)
-  GH_USERNAME: magdabot
-  # Github Orgnisation name or user name for this repo
-  GH_ORGNAME: magda-io
-
 
 jobs:
   build-test-docker:
@@ -16,22 +11,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12
+      - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
+
+      - name: Login to GitHub Container Registry
+        run: |
+          REPO_OWNER=`echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]'`
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - run: yarn install
       - run: yarn build
       - run: yarn test
-      
-      - name: helm-build-dependencies
-        run: yarn update-all-charts
 
+      - run: yarn update-all-charts
       - run: yarn helm-lint
 
-      - name: Login to GitHub Package Repository
-        env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: docker login docker.pkg.github.com -u ${GH_USERNAME} -p ${GH_TOKEN}
+      - name: Check Helm Chart Document
+        run: |
+          code=0
+          docker run --rm -v "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:v1.5.0 -t ./README.md.gotmpl -o ../../README.md || code=$?;
+          if [ "$code" != "0" ]; then 
+            echo "Failed to run helm-docs!";
+            exit 1;
+          fi;
+          cd deploy
+          code=0
+          git ls-files -m | grep -i readme.md || code=$?;
+          if [ "$code" == "0" ]; then
+            echo -e "Some of helm chart docs are required to be updated using the [helm-docs](https://github.com/norwoodj/helm-docs) tool. \n
+            Please run helm-docs (v1.5.0) at project root, review & commit docs changes and push a new commit.";
+            exit 1;
+          else 
+            echo -e "helm docs check passed. helm docs update is not required.";
+          fi;
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Build Docker Image & Push
-        run: yarn docker-build-prod --repository=docker.pkg.github.com/${GH_ORGNAME}/${REPO_NAME} --name=${REPO_NAME} --version=${GITHUB_SHA}
+        run: |
+          REPO_OWNER=`echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]'`
+          yarn docker-build-prod --repository=ghcr.io/${REPO_OWNER} --name=${REPO_NAME} --version=${GITHUB_SHA} --platform=linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check Helm Chart Document
         run: |
           code=0
-          docker run --rm -v "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:v1.5.0 -t ./README.md.gotmpl -o ../../README.md || code=$?;
+          yarn helm-docs || code=$?;
           if [ "$code" != "0" ]; then 
             echo "Failed to run helm-docs!";
             exit 1;
@@ -43,7 +43,7 @@ jobs:
           git ls-files -m | grep -i readme.md || code=$?;
           if [ "$code" == "0" ]; then
             echo -e "Some of helm chart docs are required to be updated using the [helm-docs](https://github.com/norwoodj/helm-docs) tool. \n
-            Please run helm-docs (v1.5.0) at project root, review & commit docs changes and push a new commit.";
+            Please run helm-docs (v1.11.0) at project root, review & commit docs changes and push a new commit.";
             exit 1;
           else 
             echo -e "helm docs check passed. helm docs update is not required.";

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,7 @@ on:
     types: [published]
 
 env:
-  # [avoid issue when Github action upgraded from 18.04 default to 20.04](https://github.com/aws/aws-cli/issues/5262)
-  AWS_EC2_METADATA_DISABLED: true
   REPO_NAME: magda-auth-oidc
-  # Github account username (used for access github registry)
-  GH_USERNAME: magdabot
-  # Github Orgnisation name or user name for this repo
-  GH_ORGNAME: magda-io
-  #Docker Hub username
-  DH_USERNAME: magdabot
-  #S3 bucket name: this s3 bucket will be used to store published helm chart and index
-  S3_BUCKET: magda-charts
 
 jobs:
   release-helm-chart:
@@ -24,55 +14,67 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js 12
+      - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
+
+      - name: Login to GitHub Container Registry
+        run: |
+          REPO_OWNER=`echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]'`
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - run: yarn install
       - run: yarn build
       - run: yarn test
 
-      - name: helm-build-dependencies
-        run: yarn update-all-charts
+      - run: yarn update-all-charts
+      - run: yarn helm-lint
 
-      - name: helm-check
-        run: yarn helm-lint
-
-      - name: check-helm-chart-verion
+      - name: Check Helm Chart Document
+        run: |
+          code=0
+          docker run --rm -v "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:v1.5.0 -t ./README.md.gotmpl -o ../../README.md || code=$?;
+          if [ "$code" != "0" ]; then 
+            echo "Failed to run helm-docs!";
+            exit 1;
+          fi;
+          cd deploy
+          code=0
+          git ls-files -m | grep -i readme.md || code=$?;
+          if [ "$code" == "0" ]; then
+            echo -e "Some of helm chart docs are required to be updated using the [helm-docs](https://github.com/norwoodj/helm-docs) tool. \n
+            Please run helm-docs (v1.5.0) at project root, review & commit docs changes and push a new commit.";
+            exit 1;
+          else 
+            echo -e "helm docs check passed. helm docs update is not required.";
+          fi;
+      - name: helm-chart-version-check
         run: yarn check-helm-chart-version deploy/${REPO_NAME}/Chart.yaml
 
-      - name: Login to GitHub Package Repository
-        env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-        run: docker login docker.pkg.github.com -u ${GH_USERNAME} -p ${GH_TOKEN}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
-      - name: Build Docker Image & Push to Github Registry
-        run: yarn docker-build-prod --repository=docker.pkg.github.com/${GH_ORGNAME}/${REPO_NAME} --name=${REPO_NAME}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Login to Docker Hub
-        env:
-          DH_TOKEN: ${{ secrets.DOCKER_HUB_PASSWORD }}
-        run: docker login -u ${DH_USERNAME} -p ${DH_TOKEN}
-
-      - name: Re-tag & Push Docker Image to Docker Hub
-        run: yarn retag-and-push --fromPrefix=docker.pkg.github.com/${GH_ORGNAME}/${REPO_NAME}/ --fromName=${REPO_NAME}
-
-      - name: Configure Git
+      - name: Build Docker Image & Push
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          REPO_OWNER=`echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]'`
+          yarn docker-build-prod --repository=ghcr.io/${REPO_OWNER} --name=${REPO_NAME} --version=${GITHUB_SHA} --platform=linux/amd64,linux/arm64
+      - name: Re-tag & Push Docker Images
+        run: |
+          REPO_OWNER=`echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]'`
+          PACKAGE_JSON_VERSION=$(jq -r ".version" ./package.json)
+          chmod +r $HOME/.docker/config.json
+          # Re-push to ghcr.io
+          docker container run --rm --net host \
+            -v regctl-conf:/home/appuser/.regctl/ \
+            -v $HOME/.docker/config.json:/home/appuser/.docker/config.json \
+            regclient/regctl:v0.3.9 image copy ghcr.io/${REPO_OWNER}/${REPO_NAME}:${GITHUB_SHA} ghcr.io/${REPO_OWNER}/${REPO_NAME}:${PACKAGE_JSON_VERSION}
       - name: Release Helm Chart
-        env:
-          CR_TOKEN: "${{ secrets.GH_ACCESS_TOKEN }}"
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
+          REPO_OWNER=`echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]'`
           cd deploy
-          mkdir -p sync_dir
-          mkdir -p index_dir
-          if ! aws s3 cp s3://${S3_BUCKET}/index.yaml index_dir/index.yaml; then echo "failed to copy current repo index" && exit 1; fi
-          helm package -d sync_dir ${REPO_NAME}
-          helm repo index --merge "index_dir/index.yaml" sync_dir
-          mv -f sync_dir/index.yaml index_dir/index.yaml
-          aws s3 sync sync_dir s3://${S3_BUCKET}/
-          aws s3 cp index_dir/index.yaml s3://${S3_BUCKET}/index.yaml
+          helm package ${REPO_NAME}
+          PKG_NAME=`ls *.tgz`
+          helm push ${PKG_NAME} oci://ghcr.io/${REPO_OWNER}/charts

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# v1.2.2
+
+- Fixed #1, timeout setting didn't apply to all HTTP connections
+
 # v1.2.1
 
 - Upgrade to magda-common lib chart v1.0.0-alpha.4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+# v2.0.0
+
+- Upgrade nodejs to version 14
+- Upgrade other dependencies
+- Release all artifacts to GitHub Container Registry (instead of docker.io & https://charts.magda.io)
+- Upgrade magda-common chart version to v2.2.5
+- Build multi-arch docker images
+- add support to allowedExternalRedirectDomains config options
+- not set deployment replicas when autoscaler is on
+
 # v1.2.2
 
 - Fixed #1, timeout setting didn't apply to all HTTP connections

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:14-alpine
 
 RUN mkdir -p /usr/src/app
 COPY . /usr/src/app

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # magda-auth-oidc
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square)
 
 A Generic Magda Authentication Plugin for OpenID Connect.
 

--- a/deploy/magda-auth-oidc/Chart.lock
+++ b/deploy/magda-auth-oidc/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: magda-common
-  repository: https://charts.magda.io
-  version: 1.0.0-alpha.4
-digest: sha256:a5dcf2df16ca5a3972f92d91434c2e78be0ce411994d2a3cb89c674a711ddc24
-generated: "2021-10-13T14:59:01.604294+11:00"
+  repository: oci://ghcr.io/magda-io/charts
+  version: 2.2.5
+digest: sha256:af022738730ca04ac36a11c34a47c7e82fb582733cc3b76be6bdbcda380dbeca
+generated: "2023-08-01T13:59:38.527675+10:00"

--- a/deploy/magda-auth-oidc/Chart.yaml
+++ b/deploy/magda-auth-oidc/Chart.yaml
@@ -7,5 +7,5 @@ home: "https://github.com/magda-io/magda-auth-oidc"
 sources: [ "https://github.com/magda-io/magda-auth-oidc" ]
 dependencies:
   - name: magda-common
-    version: "1.0.0-alpha.4"
-    repository: "https://charts.magda.io"
+    version: "2.2.5"
+    repository: "oci://ghcr.io/magda-io/charts"

--- a/deploy/magda-auth-oidc/Chart.yaml
+++ b/deploy/magda-auth-oidc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: magda-auth-oidc
 description: A Generic Magda Authentication Plugin for OpenID Connect.
-version: "1.2.1"
+version: "1.2.2"
 kubeVersion: ">= 1.14.0-0"
 home: "https://github.com/magda-io/magda-auth-oidc"
 sources: [ "https://github.com/magda-io/magda-auth-oidc" ]

--- a/deploy/magda-auth-oidc/templates/configmap.yaml
+++ b/deploy/magda-auth-oidc/templates/configmap.yaml
@@ -5,4 +5,5 @@ metadata:
 data:
   # When the config map is mounted as a volume, these will be created as files.
   authPluginConfig.json: {{ .Values.authPluginConfig | mustToRawJson | quote }}
+  allowedExternalRedirectDomains.json: {{ .Values.global.authPluginAllowedExternalRedirectDomains | mustToRawJson | quote }}
 

--- a/deploy/magda-auth-oidc/templates/deployment.yaml
+++ b/deploy/magda-auth-oidc/templates/deployment.yaml
@@ -3,7 +3,9 @@ kind: Deployment
 metadata:
   name: {{ .Chart.Name }}
 spec:
+  {{- if not .Values.autoscaler.enabled }}
   replicas: {{ .Values.replicas | default 1 }}
+  {{- end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -15,6 +17,7 @@ spec:
     metadata:
       annotations:
         checksum/authPluginConfig: {{ .Values.authPluginConfig | mustToRawJson | sha256sum }}
+        checksum/allowedExternalRedirectDomains: {{ .Values.global.authPluginAllowedExternalRedirectDomains | mustToRawJson | sha256sum }}
       labels:
         service: {{ .Chart.Name }}
     spec:
@@ -33,6 +36,7 @@ spec:
             "--externalUrl", {{ .Values.global.externalUrl | quote }},
             "--authPluginRedirectUrl", {{ .Values.authPluginRedirectUrl | default .Values.global.authPluginRedirectUrl | quote }},
             "--authApiUrl", "http://authorization-api/v0",
+            "--allowedExternalRedirectDomainsConfigJson", "/etc/{{ .Chart.Name }}-config/allowedExternalRedirectDomains.json",
             "--authPluginConfigJson", "/etc/{{ .Chart.Name }}-config/authPluginConfig.json",
             "--clientId", {{ .Values.clientId | required (printf "`clientId` is required for magda auth plugin `%s`." .Chart.Name) | quote }},
             {{- if .Values.scope }}

--- a/deploy/magda-auth-oidc/values.yaml
+++ b/deploy/magda-auth-oidc/values.yaml
@@ -4,6 +4,12 @@ global:
   rollingUpdate: {}
   externalUrl: ""
   authPluginRedirectUrl: "/sign-in-redirect"
+  # -- By default, at end of authentication process, an auth plugin will never redirect the user to an external domain, 
+  # even if `authPluginRedirectUrl` is configured to an URL with an external domain.
+  # Unless an external domain is added to the whitelist i.e. this `authPluginAllowedExternalRedirectDomains` config, 
+  # any auth plugins will always ignore the domain part of the url (if supplied) and only redirect the user to the URL path under the current domain.
+  # Please note: you add a url host string to this list. e.g. "abc.com:8080"
+  authPluginAllowedExternalRedirectDomains: []
 
 # -- the redirection url after the whole authentication process is completed.
 # Authentication Plugins will use this value as default.
@@ -93,7 +99,7 @@ image:
   # imagePullSecret: 
 
 defaultImage:
-  repository: docker.io/data61
+  repository: ghcr.io/magda-io
   pullPolicy: IfNotPresent
   imagePullSecret: false
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
     "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
     "helm-lint": "helm template deploy/magda-auth-oidc -f deploy/test-deploy.yaml 1>/dev/null",
-    "helm-docs": "helm-docs -t ./README.md.gotmpl -o ../../README.md",
+    "helm-docs": "docker run --rm -v \"$(pwd):/helm-docs\" -u $(id -u) jnorwood/helm-docs:v1.11.0 -t ./README.md.gotmpl -o ../../README.md",
     "update-all-charts": "helm dep up ./deploy/magda-auth-oidc",
     "add-all-chart-version-changes": "git ls-files -m | grep Chart.yaml | xargs git add && git ls-files -m | grep Chart.lock | xargs git add",
     "add-all-helm-docs-changes": "yarn helm-docs && git ls-files -m | grep -i readme.md | xargs git add",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@magda/ci-utils": "^1.0.2",
-    "@magda/docker-utils": "^0.0.60",
+    "@magda/docker-utils": "^2.2.5",
     "@types/express": "^4.0.37",
     "@types/lodash": "^4.14.162",
     "@types/mocha": "^8.0.3",
@@ -38,13 +38,13 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
-    "@magda/auth-api-client": "^0.0.60",
-    "@magda/authentication-plugin-sdk": "^0.0.60",
+    "@magda/auth-api-client": "^2.2.5",
+    "@magda/authentication-plugin-sdk": "^2.2.5",
     "express": "^4.15.4",
     "lodash": "^4.17.20",
     "openid-client": "3.12.2",
     "passport": "0.2.2",
-    "urijs": "^1.19.2",
+    "urijs": "^1.19.11",
     "yargs": "^16.1.0"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magda-auth-oidc",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A Generic Magda Authentication Plugin for OpenID Connect",
   "repository": "https://github.com/magda-io/magda-auth-oidc.git",
   "author": "Jacky Jiang",

--- a/src/createAuthPluginRouter.ts
+++ b/src/createAuthPluginRouter.ts
@@ -91,6 +91,11 @@ async function createOpenIdClient(options: AuthPluginRouterOptions) {
     );
     const authPluginConfig = options.authPluginConfig;
 
+    custom.setHttpOptionsDefaults({
+        ...customizeUserAgent({}),
+        timeout: options?.timeout || OIDC_DEFAULT_TIMEOUT
+    });
+
     Issuer[custom.http_options] = function (opts) {
         opts = customizeUserAgent(opts);
         opts.timeout = options?.timeout || OIDC_DEFAULT_TIMEOUT;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,13 @@ const argv = yargs
         type: "string",
         coerce: coerceJson
     })
+    .option("allowedExternalRedirectDomainsConfigJson", {
+        describe:
+            "allowedExternalRedirectDomains" +
+            "See https://github.com/magda-io/magda/blob/master/docs/docs/authentication-plugin-spec.md.",
+        type: "string",
+        coerce: coerceJson
+    })
     .option("externalUrl", {
         describe: "The base external URL of the gateway.",
         type: "string",
@@ -111,6 +118,10 @@ const argv = yargs
     }).argv;
 
 const authPluginConfig = argv.authPluginConfigJson as any as AuthPluginConfig;
+const allowedExternalRedirectDomains = argv
+    ?.allowedExternalRedirectDomainsConfigJson?.length
+    ? (argv.allowedExternalRedirectDomainsConfigJson as any as string[])
+    : ([] as string[]);
 
 // Create a new Express application.
 const app = express();
@@ -184,7 +195,8 @@ const authApiClient = new AuthApiClient(
             authPluginConfig,
             scope: argv?.scope,
             timeout: argv?.timeout,
-            maxClockSkew: argv?.maxClockSkew
+            maxClockSkew: argv?.maxClockSkew,
+            allowedExternalRedirectDomains
         });
         app.use(routes);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,23 +2,23 @@
 # yarn lockfile v1
 
 
-"@magda/auth-api-client@^0.0.60":
-  version "0.0.60"
-  resolved "https://registry.yarnpkg.com/@magda/auth-api-client/-/auth-api-client-0.0.60.tgz#b001a3df51a8e5a6c65c65945a320047ba19c599"
-  integrity sha512-XW7pTyE47i+Uy6KPZuZz5CZfSRcmROWYZ08zH5G+raS2yadscrqFD6YWOSBNOpCG1GXbI8NEZhVuwOhmLFJjRQ==
+"@magda/auth-api-client@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@magda/auth-api-client/-/auth-api-client-2.2.5.tgz#e96cdb00f21845524e0152bea3fae3abc86e903f"
+  integrity sha512-MKycwaCLynbsxjljzv9B33XlISC2FJoNFwJNqs3WjXp7Y9sSv/kTEmpvzyrXOxl39XvfaDbbCq/NoqtjtLYfhw==
 
-"@magda/authentication-plugin-sdk@^0.0.60":
-  version "0.0.60"
-  resolved "https://registry.yarnpkg.com/@magda/authentication-plugin-sdk/-/authentication-plugin-sdk-0.0.60.tgz#c99da82f658a44450c4d95ed2dd76b23a2a53d05"
-  integrity sha512-O+vMm1yQ/Uo4lF/EeuCVWTPWlPmu75FNa4nIrl73dLbU+9XW9RSIKnAOiGdRlFMTL494wCCicfBoU24ojlqpVA==
+"@magda/authentication-plugin-sdk@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@magda/authentication-plugin-sdk/-/authentication-plugin-sdk-2.2.5.tgz#2459d97a1910e16b9bc8fc5983cb5ff1a2a0ef43"
+  integrity sha512-4qMjxx26YKbNKBbJH3GYdGosQaUcfZKuSl5jx+6o4FPkDeC0JgpwGJVsU6gJ1fM/Ubobn30EQil+Ee8wwonTYg==
   dependencies:
-    connect-pg-simple "^6.0.1"
+    connect-pg-simple "^6.2.1"
     cookie-parser "^1.4.5"
     express "^4.17.1"
     express-session "^1.17.1"
     lodash "^4.17.4"
-    pg "^6.4.0"
-    urijs "^1.19.4"
+    pg "^8.7.3"
+    urijs "^1.19.11"
 
 "@magda/ci-utils@^1.0.2":
   version "1.0.2"
@@ -29,10 +29,10 @@
     recursive-readdir "^2.2.2"
     yaml "^1.10.2"
 
-"@magda/docker-utils@^0.0.60":
-  version "0.0.60"
-  resolved "https://registry.yarnpkg.com/@magda/docker-utils/-/docker-utils-0.0.60.tgz#7e2002ebdb1472e3206c8e9b8f53730ac298dc33"
-  integrity sha512-jU6mYYeBPkm1cciDOiOqOlSn0Ru5BdhTkpL2qHq3nU+DMLNlgDCHD0sGyCm1iPRaDlo75igO200bFQAR1551pg==
+"@magda/docker-utils@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@magda/docker-utils/-/docker-utils-2.2.5.tgz#b27e9c3c7be57023ef196fe8a572957232f3fe66"
+  integrity sha512-dHtx83tsO3GfxIzNa4J3rjtfVlv/kdLe1pIJL9Kpc8vnAf2gucX52pqB86dJ3c0E1xgOwJv0nKBkDAafmUM7Tg==
   dependencies:
     fs-extra "^2.1.2"
     is-subdir "^1.0.2"
@@ -337,11 +337,6 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-buffer-writer@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-1.0.1.tgz#22a936901e3029afcd7547eb4487ceb697a3bf08"
-  integrity sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg=
-
 buffer-writer@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
@@ -478,7 +473,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-connect-pg-simple@^6.0.1:
+connect-pg-simple@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/connect-pg-simple/-/connect-pg-simple-6.2.1.tgz#21c3e7ff6223030afff230621eac53eaae3b1797"
   integrity sha512-bwDp/gKyRtyz0V5Vxy3SATSxItWBK/wDhaacncC79+q1B1VB8SQ49AlVaQCM+XxmIO29cWX4cvsFj65mD2qrzA==
@@ -795,11 +790,6 @@ fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
-generic-pool@2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.4.3.tgz#780c36f69dfad05a5a045dd37be7adca11a4f6ff"
-  integrity sha1-eAw29p360FpaBF3Te+etyhGk9v8=
-
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
@@ -932,7 +922,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3:
+inherits@2, inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1026,11 +1016,6 @@ jose@^1.22.0:
   integrity sha512-JmfDRzt/HSj8ipd9TsDtEHoLUnLYavG+7e8F6s1mx2jfVSfXOTaFQsJUydbjJpTnTDHP1+yKL9Ke7ktS/a0Eiw==
   dependencies:
     "@panva/asn1.js" "^1.0.0"
-
-js-string-escape@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/js-string-escape/-/js-string-escape-1.0.1.tgz#e2625badbc0d67c7533e9edc1068c587ae4137ef"
-  integrity sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=
 
 js-yaml@3.14.0:
   version "3.14.0"
@@ -1289,11 +1274,6 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-object-assign@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
-  integrity sha1-ejs9DpgGPUP0wD8uiubNUahog6A=
-
 object-hash@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.1.1.tgz#9447d0279b4fcf80cff3259bf66a1dc73afabe09"
@@ -1423,11 +1403,6 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-packet-reader@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-0.3.1.tgz#cd62e60af8d7fea8a705ec4ff990871c46871f27"
-  integrity sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc=
-
 packet-reader@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-1.0.0.tgz#9238e5480dedabacfe1fe3f2771063f164157d74"
@@ -1481,49 +1456,45 @@ pause@0.0.1:
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
   integrity sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=
 
-pg-connection-string@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
-  integrity sha1-2hhHsglA5C7hSSvq9l1J2RskXfc=
+pg-cloudflare@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz#e6d5833015b170e23ae819e8c5d7eaedb472ca98"
+  integrity sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==
 
 pg-connection-string@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.4.0.tgz#c979922eb47832999a204da5dbe1ebf2341b6a10"
   integrity sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==
 
+pg-connection-string@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.6.2.tgz#713d82053de4e2bd166fab70cd4f26ad36aab475"
+  integrity sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==
+
 pg-int8@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/pg-int8/-/pg-int8-1.0.1.tgz#943bd463bf5b71b4170115f80f8efc9a0c0eb78c"
   integrity sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==
-
-pg-pool@1.*:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-1.8.0.tgz#f7ec73824c37a03f076f51bfdf70e340147c4f37"
-  integrity sha1-9+xzgkw3oD8Hb1G/33DjQBR8Tzc=
-  dependencies:
-    generic-pool "2.4.3"
-    object-assign "4.1.0"
 
 pg-pool@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.2.1.tgz#5f4afc0f58063659aeefa952d36af49fa28b30e0"
   integrity sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==
 
+pg-pool@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-3.6.1.tgz#5a902eda79a8d7e3c928b77abf776b3cb7d351f7"
+  integrity sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==
+
 pg-protocol@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.3.0.tgz#3c8fb7ca34dbbfcc42776ce34ac5f537d6e34770"
   integrity sha512-64/bYByMrhWULUaCd+6/72c9PMWhiVFs3EVxl9Ct6a3v/U8+rKgqP2w+kKg/BIGgMJyB+Bk/eNivT32Al+Jghw==
 
-pg-types@1.*:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-1.13.0.tgz#75f490b8a8abf75f1386ef5ec4455ecf6b345c63"
-  integrity sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==
-  dependencies:
-    pg-int8 "1.0.1"
-    postgres-array "~1.0.0"
-    postgres-bytea "~1.0.0"
-    postgres-date "~1.0.0"
-    postgres-interval "^1.1.0"
+pg-protocol@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/pg-protocol/-/pg-protocol-1.6.0.tgz#4c91613c0315349363af2084608db843502f8833"
+  integrity sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==
 
 pg-types@^2.1.0:
   version "2.2.0"
@@ -1535,20 +1506,6 @@ pg-types@^2.1.0:
     postgres-bytea "~1.0.0"
     postgres-date "~1.0.4"
     postgres-interval "^1.1.0"
-
-pg@^6.4.0:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/pg/-/pg-6.4.2.tgz#c364011060eac7a507a2ae063eb857ece910e27f"
-  integrity sha1-w2QBEGDqx6UHoq4GPrhX7OkQ4n8=
-  dependencies:
-    buffer-writer "1.0.1"
-    js-string-escape "1.0.1"
-    packet-reader "0.3.1"
-    pg-connection-string "0.1.3"
-    pg-pool "1.*"
-    pg-types "1.*"
-    pgpass "1.*"
-    semver "4.3.2"
 
 pg@^8.2.1:
   version "8.4.1"
@@ -1563,12 +1520,20 @@ pg@^8.2.1:
     pg-types "^2.1.0"
     pgpass "1.x"
 
-pgpass@1.*:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.4.tgz#85eb93a83800b20f8057a2b029bf05abaf94ea9c"
-  integrity sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==
+pg@^8.7.3:
+  version "8.11.2"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-8.11.2.tgz#1a23f6de7bfb65ba56e4dd15df96668d319900c4"
+  integrity sha512-l4rmVeV8qTIrrPrIR3kZQqBgSN93331s9i6wiUiLOSk0Q7PmUxZD/m1rQI622l3NfqBby9Ar5PABfS/SulfieQ==
   dependencies:
-    split2 "^3.1.1"
+    buffer-writer "2.0.0"
+    packet-reader "1.0.0"
+    pg-connection-string "^2.6.2"
+    pg-pool "^3.6.1"
+    pg-protocol "^1.6.0"
+    pg-types "^2.1.0"
+    pgpass "1.x"
+  optionalDependencies:
+    pg-cloudflare "^1.1.1"
 
 pgpass@1.x:
   version "1.0.2"
@@ -1582,11 +1547,6 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
-postgres-array@~1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-1.0.3.tgz#c561fc3b266b21451fc6555384f4986d78ec80f5"
-  integrity sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ==
-
 postgres-array@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
@@ -1597,7 +1557,7 @@ postgres-bytea@~1.0.0:
   resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
   integrity sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=
 
-postgres-date@~1.0.0, postgres-date@~1.0.4:
+postgres-date@~1.0.4:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.7.tgz#51bc086006005e5061c591cee727f2531bf641a8"
   integrity sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==
@@ -1662,15 +1622,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-readable-stream@^3.0.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
 readdirp@~3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
@@ -1724,7 +1675,7 @@ safe-buffer@5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
-safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -1733,11 +1684,6 @@ safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-semver@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
-  integrity sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
 
 semver@^5.5.0:
   version "5.7.1"
@@ -1820,13 +1766,6 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-split2@^3.1.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
-  integrity sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==
-  dependencies:
-    readable-stream "^3.0.0"
-
 split@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
@@ -1878,13 +1817,6 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -1999,15 +1931,10 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
-urijs@^1.19.2:
-  version "1.19.2"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.2.tgz#f9be09f00c4c5134b7cb3cf475c1dd394526265a"
-  integrity sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==
-
-urijs@^1.19.4:
-  version "1.19.6"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.6.tgz#51f8cb17ca16faefb20b9a31ac60f84aa2b7c870"
-  integrity sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw==
+urijs@^1.19.11:
+  version "1.19.11"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
+  integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
 
 url-parse-lax@^3.0.0:
   version "3.0.0"
@@ -2015,11 +1942,6 @@ url-parse-lax@^3.0.0:
   integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
   dependencies:
     prepend-http "^2.0.0"
-
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 utils-merge@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### What this PR does

- Upgrade nodejs to version 14
- Upgrade other dependencies
- Release all artifacts to GitHub Container Registry (instead of docker.io & https://charts.magda.io)
- Upgrade magda-common chart version to v2.2.5
- Build multi-arch docker images
- add support to allowedExternalRedirectDomains config options
- not set deployment replicas when autoscaler is on

### Checklist

-   [x] unit tests aren't applicable
-   [x] I've updated CHANGES.md with what I changed.
