### PR TITLE
Bump version to v3.0.0-alpha.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # magda-auth-oidc
 
-![Version: 2.0.4](https://img.shields.io/badge/Version-2.0.4-informational?style=flat-square)
+![Version: 3.0.0-alpha.0](https://img.shields.io/badge/Version-3.0.0--alpha.0-informational?style=flat-square)
 
 A Generic Magda Authentication Plugin for OpenID Connect.
 

--- a/deploy/magda-auth-oidc/Chart.yaml
+++ b/deploy/magda-auth-oidc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: magda-auth-oidc
 description: A Generic Magda Authentication Plugin for OpenID Connect.
-version: "2.0.4"
+version: "3.0.0-alpha.0"
 kubeVersion: ">= 1.14.0-0"
 home: "https://github.com/magda-io/magda-auth-oidc"
 sources: [ "https://github.com/magda-io/magda-auth-oidc" ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magda-auth-oidc",
-  "version": "2.0.4",
+  "version": "3.0.0-alpha.0",
   "description": "A Generic Magda Authentication Plugin for OpenID Connect",
   "repository": "https://github.com/magda-io/magda-auth-oidc.git",
   "author": "Jacky Jiang",


### PR DESCRIPTION
Merges the `v3.0.0-alpha.0` version bump back into `main`. Version-only; the chart + image are already published.